### PR TITLE
bugfix: Missing mod.ts, imports and more

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -26,12 +26,14 @@
     }
   },
   "compilerOptions": {
-    "allowJs": true,
     "lib": ["deno.window"],
     "strict": true
   },
   "imports": {
-    "@std/": "https://deno.land/std@0.208.0/",
+    "@std/assert": "jsr:@std/assert@^1.0.5",
+    "@std/flags": "jsr:@std/flags@^0.224.0", 
+    "@std/path": "jsr:@std/path@^1.1.2",
+    "@std/fs": "jsr:@std/fs@^1.0.19",
     "@upstash/context7-mcp": "npm:@upstash/context7-mcp"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,42 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@0.224": "0.224.0",
+    "jsr:@std/flags@*": "0.224.0",
+    "jsr:@std/flags@0.224": "0.224.0",
+    "jsr:@std/fs@^1.0.19": "1.0.19",
+    "jsr:@std/internal@^1.0.10": "1.0.10",
+    "jsr:@std/internal@^1.0.9": "1.0.10",
+    "jsr:@std/path@^1.1.1": "1.1.2",
+    "jsr:@std/path@^1.1.2": "1.1.2",
     "npm:@upstash/context7-mcp@*": "1.0.17"
+  },
+  "jsr": {
+    "@std/assert@0.224.0": {
+      "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f"
+    },
+    "@std/flags@0.224.0": {
+      "integrity": "d40eaf58c356b2e1313c6d4e62dc28b614aad2ddae6f5ff72a969e0b1f5ad689",
+      "dependencies": [
+        "jsr:@std/assert"
+      ]
+    },
+    "@std/fs@1.0.19": {
+      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.9",
+        "jsr:@std/path@^1.1.1"
+      ]
+    },
+    "@std/internal@1.0.10": {
+      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    },
+    "@std/path@1.1.2": {
+      "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.10"
+      ]
+    }
   },
   "npm": {
     "@modelcontextprotocol/sdk@1.17.3_express@5.1.0_zod@3.25.76": {
@@ -643,6 +678,10 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@std/assert@^1.0.5",
+      "jsr:@std/flags@0.224",
+      "jsr:@std/fs@^1.0.19",
+      "jsr:@std/path@^1.1.2",
       "npm:@upstash/context7-mcp@*"
     ]
   }

--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,44 @@
+/**
+ * Rampante - AI Agent Orchestrator for Spec-Driven Development
+ * 
+ * A multi-CLI slash command system that automates the complete spec-driven 
+ * development workflow using YOLO strategy for stack selection.
+ * 
+ * @module rampante
+ * @version 0.1.0
+ * @author Page Carbajal
+ * @license MIT
+ */
+
+// Export main CLI functionality
+export { main } from './src/cli/install.ts';
+
+// Export core services
+export { installAssets } from './src/services/install_assets.ts';
+export { configureContext7 } from './src/services/context7_config.ts';
+export { registerRampante } from './src/services/register_rampante.ts';
+export { installScripts } from './src/services/install_scripts.ts';
+
+// Export utilities
+export { selectStack, getAvailableStacks, validateStackFile } from './src/lib/stack_selection.ts';
+export { Logger, RampanteError, ErrorHandler } from './src/lib/logger.ts';
+export { 
+  expandHome, 
+  ensureDirExists, 
+  safeWriteFile, 
+  safeCopyFile, 
+  safeRemove, 
+  pathExists, 
+  getAbsolutePath 
+} from './src/lib/fs_utils.ts';
+
+// Export types
+export type { 
+  StackInfo, 
+  StackSelectionResult 
+} from './src/lib/stack_selection.ts';
+
+// Package metadata
+export const VERSION = '0.1.0';
+export const NAME = '@page-carbajal/rampante';
+export const DESCRIPTION = 'AI Agent Orchestrator for Spec-Driven Development';

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -11,7 +11,7 @@
  *   deno run npm:run-rampante install codex --force
  */
 
-import { parse as parseArgs } from "https://deno.land/std@0.208.0/flags/mod.ts";
+import { parse as parseArgs } from "@std/flags";
 import { installAssets } from "../services/install_assets.ts";
 import { configureContext7 } from "../services/context7_config.ts";
 import { registerRampante } from "../services/register_rampante.ts";

--- a/src/lib/fs_utils.ts
+++ b/src/lib/fs_utils.ts
@@ -7,8 +7,8 @@
  * - Safe file operations (write, copy, remove)
  */
 
-import { join, resolve, dirname } from 'https://deno.land/std@0.208.0/path/mod.ts';
-import { ensureDir, exists, copy } from 'https://deno.land/std@0.208.0/fs/mod.ts';
+import { join, resolve, dirname } from '@std/path';
+import { ensureDir, exists, copy } from '@std/fs';
 
 /**
  * Expand ~ to home directory path

--- a/src/lib/stack_selection.ts
+++ b/src/lib/stack_selection.ts
@@ -8,7 +8,7 @@
  * - Extract technologies from selected stack file
  */
 
-import { join } from 'https://deno.land/std@0.208.0/path/mod.ts';
+import { join } from '@std/path';
 import { pathExists } from './fs_utils.ts';
 
 export interface StackInfo {

--- a/src/services/context7_config.ts
+++ b/src/services/context7_config.ts
@@ -7,7 +7,7 @@
  * Creates config files if missing and adds mcp_servers.context7 section
  */
 
-import { join } from "https://deno.land/std@0.208.0/path/mod.ts";
+import { join } from "@std/path";
 import {
   ensureDirExists,
   safeWriteFile,

--- a/src/services/install_assets.ts
+++ b/src/services/install_assets.ts
@@ -8,7 +8,7 @@
  * Supports idempotent operations and --force flag
  */
 
-import { join } from "https://deno.land/std@0.208.0/path/mod.ts";
+import { join } from "@std/path";
 import { safeWriteFile, ensureDirExists, safeRemove } from "../lib/fs_utils.ts";
 import { logger, RampanteError, ErrorHandler } from "../lib/logger.ts";
 

--- a/src/services/install_scripts.ts
+++ b/src/services/install_scripts.ts
@@ -8,7 +8,7 @@
  * Supports idempotent operations and --force flag
  */
 
-import { join } from 'https://deno.land/std@0.208.0/path/mod.ts';
+import { join } from '@std/path';
 import { ensureDirExists, safeWriteFile, pathExists } from '../lib/fs_utils.ts';
 import { logger, RampanteError, ErrorHandler } from '../lib/logger.ts';
 

--- a/src/services/register_rampante.ts
+++ b/src/services/register_rampante.ts
@@ -7,7 +7,7 @@
  * Future phases will support Claude Code, Gemini, etc.
  */
 
-import { join } from 'https://deno.land/std@0.208.0/path/mod.ts';
+import { join } from '@std/path';
 import { safeCopyFile, ensureDirExists, pathExists, expandHome } from '../lib/fs_utils.ts';
 import { logger, RampanteError, ErrorHandler } from '../lib/logger.ts';
 

--- a/tests/unit/test_stack_and_register.ts
+++ b/tests/unit/test_stack_and_register.ts
@@ -1,6 +1,6 @@
-import { assertEquals, assertExists, assert, assertRejects } from "https://deno.land/std@0.208.0/testing/asserts.ts";
-import { join } from "https://deno.land/std@0.208.0/path/mod.ts";
-import { exists } from "https://deno.land/std@0.208.0/fs/mod.ts";
+import { assertEquals, assertExists, assert, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+import { exists } from "@std/fs";
 import { 
   registerRampante, 
   getRegistrationPath, 

--- a/tests/unit/test_stack_selection.ts
+++ b/tests/unit/test_stack_selection.ts
@@ -1,5 +1,5 @@
-import { assertEquals, assertExists, assert } from "https://deno.land/std@0.208.0/testing/asserts.ts";
-import { join } from "https://deno.land/std@0.208.0/path/mod.ts";
+import { assertEquals, assertExists, assert } from "@std/assert";
+import { join } from "@std/path";
 import { 
   selectStack, 
   getAvailableStacks, 


### PR DESCRIPTION
- Added mod.ts file at repository root as the main export entry
- Exported all public APIs (CLI, services, utilities, types)
- Added package metadata

### Updated Import Specifications for JSR Compatibility

- Replaced all https://deno.land/std@0.208.0/* imports with JSR format
- Updated deno.json imports map to use JSR specifiers:
  - @std/assert: jsr:@std/assert@^1.0.5
  - @std/flags: jsr:@std/flags@^0.224.0
  - @std/path: jsr:@std/path@^1.1.2
  - @std/fs: jsr:@std/fs@^1.0.19

### Removed Unsupported Compiler Options

- Removed allowJs: true from compilerOptions (not supported by JSR)
- Kept only supported options: lib and strict

### Updated Source Files

- Updated all import statements across the codebase to use the new JSR-compatible imports
- Fixed imports in core services, libraries, and test files
- Maintained functionality while ensuring JSR compatibility
